### PR TITLE
bugfix - typo in vulkan/Instance.hpp that prevented build on Linux

### DIFF
--- a/src/vulkan/Instance.hpp
+++ b/src/vulkan/Instance.hpp
@@ -9,7 +9,7 @@ public:
 	Instance();
 	~Instance();
 
-	const VkInstance instance() { return m_instance; }
+	VkInstance instance() { return m_instance; }
 	const std::vector<std::string>& extensions() { return m_extensions; }
 private:
 	VkInstance m_instance;


### PR DESCRIPTION
*Removed unnecessary const in vulkan/Instance.hpp
*Successful build on Ubuntu 22.04 with cmake 3.22.1